### PR TITLE
feat: colorized art

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,12 +45,12 @@ fn stitch<'a>(left: &'a str, right: &'a str) -> String {
 
     let mut result = String::new();
 
-    result.push_str(my_iterator(left, 0));
+    result.push_str(&left.lines().nth(0).unwrap().white().to_string());
     result.push_str(my_iterator(right, 0));
 
     for n in 1..num_lines {
         result.push('\n');
-        result.push_str(my_iterator(left, n));
+        result.push_str(&left.lines().nth(n).unwrap().white().to_string());
         result.push_str(my_iterator(right, n));
     }
 


### PR DESCRIPTION
Resolves #1 

These changes introduce a feature to colorize the left part of `minifetch`'s output, which is the half dedicated to the multi-line art.

Previously, color data was stored solely at the beginning of the art string, which means all but the first line would lose that color data. The solution lies in colorizing each line individually. This was most easily implemented by refactoring the `stitch` function.